### PR TITLE
Fixed name splitting for IW/MW fused CS output

### DIFF
--- a/src/GameImageUtil/GameImageUtil/data/scripts/CoDFusedCSProcessor.cs_script
+++ b/src/GameImageUtil/GameImageUtil/data/scripts/CoDFusedCSProcessor.cs_script
@@ -66,7 +66,7 @@ namespace GameImageUtil
                 var outputPath = config.GetValue("OutputPath", "");
 
                 if(string.IsNullOrWhiteSpace(outputPath))
-                    outputPath = Path.Combine(Path.GetDirectoryName(file), Path.GetFileNameWithoutExtension(file).Split(new string[] { "_n&", "_n_" }, StringSplitOptions.None)[0]);
+                    outputPath = Path.Combine(Path.GetDirectoryName(file), Path.GetFileNameWithoutExtension(file).Split(new string[] { "_c&", "_c_" }, StringSplitOptions.None)[0]);
 
                 // Force the image to a standard format
                 inputImage.ConvertImage(ScratchImage.DXGIFormat.R8G8B8A8UNORM);


### PR DESCRIPTION
it was expecting the `_n` ending in the filename, i don't think it should do that
![explorer_2021-04-21_15-13-05](https://user-images.githubusercontent.com/5104603/115554067-c2bf5a00-a2b6-11eb-8726-86d35ce9aef1.png)