### PR TITLE
Fixed colour change when splitting colour/specular from mw2019/iw

### DIFF
--- a/src/GameImageUtil/GameImageUtil/data/scripts/CoDFusedCSProcessor.cs_script
+++ b/src/GameImageUtil/GameImageUtil/data/scripts/CoDFusedCSProcessor.cs_script
@@ -84,7 +84,7 @@ namespace GameImageUtil
                             // Compute Metal/Diffuse Mask Values
                             var m = MathUtilities.Clamp(pixel.W - 0.0f, 1.0f, 0.0f) * (1.0f / (1.0f - 0.0f));
                             var d = MathUtilities.Clamp(1.0f - m, 1.0f, 0.0f);
-                            var r = Math.Min(pixel.W, insulatorSpecRange);
+                            var r = Math.Min(pixel.W, 0.0f);
 
                             // Set pixels, clamped to 56/56/56
                             cMap.SetPixel(0, 0, 0, x, y, new Vector4(pixel.X * d, pixel.Y * d, pixel.Z * d, 1.0f));

--- a/src/GameImageUtil/GameImageUtil/data/scripts/CoDFusedCSProcessor.cs_script
+++ b/src/GameImageUtil/GameImageUtil/data/scripts/CoDFusedCSProcessor.cs_script
@@ -71,8 +71,6 @@ namespace GameImageUtil
                 // Force the image to a standard format
                 inputImage.ConvertImage(ScratchImage.DXGIFormat.R8G8B8A8UNORM);
 
-                const float insulatorSpecRange = 0.1f;
-
                 using (var cMap = new ScratchImage(inputImage.Metadata))
                 using (var sMap = new ScratchImage(inputImage.Metadata))
                 {
@@ -84,7 +82,7 @@ namespace GameImageUtil
                             var pixel = inputImage.GetPixel(0, 0, 0, x, y);
 
                             // Compute Metal/Diffuse Mask Values
-                            var m = MathUtilities.Clamp(pixel.W - insulatorSpecRange, 1.0f, 0.0f) * (1.0f / (1.0f - insulatorSpecRange));
+                            var m = MathUtilities.Clamp(pixel.W - 0.0f, 1.0f, 0.0f) * (1.0f / (1.0f - 0.0f));
                             var d = MathUtilities.Clamp(1.0f - m, 1.0f, 0.0f);
                             var r = Math.Min(pixel.W, insulatorSpecRange);
 


### PR DESCRIPTION
Fixes colour when convert textures from mw2019 and iw.

Saw someone on the discord talking about having a issue with the gold on his m1911 variant and decided to fix it.
insulatorSpecRange seems to cause a issue when used at 0.1f causing it to shift gold to cyan as a example so just getting rid of it and setting the lines asking for insulatorSpecRange to 0.0f seems to fix it.

insulatorSpecRange set at 0.1f
![insulatorSpecRange_01f](https://user-images.githubusercontent.com/42575075/128542644-e704c479-15c2-4813-a8b2-1dee39dc1a0d.png)

insulatorSpecRange set to 0.0f
![insulatorSpecRange_0f](https://user-images.githubusercontent.com/42575075/128542674-3a0eac31-3958-43d9-83c1-7560c6a4d5b9.png)

what part of the gun the reference texture comes from
![part of gun that reference texutre uses](https://user-images.githubusercontent.com/42575075/128543080-05ccaf98-b064-4bd6-b59f-1cf73805e3b3.png)


