### PR TITLE
XY NM Blue channel recalculation fix/improvement

### DIFF
--- a/src/GameImageUtil/GameImageUtil/data/scripts/BC5XYNormalMapProcessor.cs_script
+++ b/src/GameImageUtil/GameImageUtil/data/scripts/BC5XYNormalMapProcessor.cs_script
@@ -18,6 +18,7 @@
 using System;
 using System.IO;
 using System.Numerics;
+using PhilLibX;
 using PhilLibX.Imaging;
 
 namespace GameImageUtil
@@ -68,9 +69,11 @@ namespace GameImageUtil
 
                         var nX = pixel.X * 2.0f - 1.0f;
                         var nY = pixel.Y * 2.0f - 1.0f;
-                        var nZ = 1.0f - (nX * nX) - (nY * nY);
 
-                        image.SetPixel(0, 0, 0, x, y, new Vector4(nX * 0.5f + 0.5f, nY * 0.5f + 0.5f, nZ > 0.0f ? (float)Math.Sqrt(nZ) * 0.5f + 0.5f : 0.0f, 1.0f));
+                        var dot1 = 1.0f - (nX * nX) - (nY * nY);
+                        var nZ = dot1 > 0 ? (float)Math.Sqrt(dot1) : 0.0f;
+
+                        image.SetPixel(0, 0, 0, x, y, new Vector4(nX * 0.5f + 0.5f, nY * 0.5f + 0.5f, MathUtilities.Clamp(nZ * 0.5f + 0.5f, 1.0f, 0.0f), 1.0f));
                     }
                 }
 


### PR DESCRIPTION
Simple comparison:
![simple_comparison](https://user-images.githubusercontent.com/57007485/145682863-46788f3a-7d68-4a9c-8dd8-fdebc2133c71.png)


Aiming to fix artifacts like these caused by the incorrect values:
![image](https://user-images.githubusercontent.com/57007485/145682916-922d21ea-5a22-4187-b7ec-bc5ad6a5cb66.png)

Differences on a normal map from Apex Legends (blue channel only):
![apexlegendsnmcomp](https://user-images.githubusercontent.com/57007485/145683166-dcb76265-3883-4092-bf29-e36f0e5a0a2b.png)

